### PR TITLE
Change the file names expected for developer credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 client_secret.json
 application_credentials.json
 credentials.json
+token.json

--- a/adminSDK/directory/index.js
+++ b/adminSDK/directory/index.js
@@ -23,12 +23,10 @@ const GoogleAuth = require('google-auth-library');
 // If modifying these scopes, delete your previously saved credentials
 // at ~/.credentials/admin-directory_v1-nodejs-quickstart.json
 const SCOPES = ['https://www.googleapis.com/auth/admin.directory.user'];
-const TOKEN_DIR = (process.env.HOME || process.env.HOMEPATH ||
-    process.env.USERPROFILE) + '/.credentials/';
-const TOKEN_PATH = TOKEN_DIR + 'admin-directory_v1-nodejs-quickstart.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', function processClientSecrets(err, content) {
+fs.readFile('credentials.json', function processClientSecrets(err, content) {
   if (err) {
     console.log('Error loading client secret file: ' + err);
     return;

--- a/adminSDK/reports/index.js
+++ b/adminSDK/reports/index.js
@@ -23,12 +23,10 @@ const GoogleAuth = require('google-auth-library');
 // If modifying these scopes, delete your previously saved credentials
 // at ~/.credentials/admin-reports_v1-nodejs-quickstart.json
 const SCOPES = ['https://www.googleapis.com/auth/admin.reports.audit.readonly'];
-const TOKEN_DIR = (process.env.HOME || process.env.HOMEPATH ||
-    process.env.USERPROFILE) + '/.credentials/';
-const TOKEN_PATH = TOKEN_DIR + 'admin-reports_v1-nodejs-quickstart.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', function processClientSecrets(err, content) {
+fs.readFile('credentials.json', function processClientSecrets(err, content) {
   if (err) {
     console.log('Error loading client secret file: ' + err);
     return;

--- a/adminSDK/reseller/index.js
+++ b/adminSDK/reseller/index.js
@@ -23,12 +23,10 @@ const GoogleAuth = require('google-auth-library');
 // If modifying these scopes, delete your previously saved credentials
 // at ~/.credentials/reseller-nodejs-quickstart.json
 const SCOPES = ['https://www.googleapis.com/auth/apps.order'];
-const TOKEN_DIR = (process.env.HOME || process.env.HOMEPATH ||
-    process.env.USERPROFILE) + '/.credentials/';
-const TOKEN_PATH = TOKEN_DIR + 'reseller-nodejs-quickstart.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', function processClientSecrets(err, content) {
+fs.readFile('credentials.json', function processClientSecrets(err, content) {
   if (err) {
     console.log('Error loading client secret file: ' + err);
     return;

--- a/apps-script/quickstart/index.js
+++ b/apps-script/quickstart/index.js
@@ -21,12 +21,12 @@ const {google} = require('googleapis');
 
 // If modifying these scopes, delete credentials.json.
 const SCOPES = ['https://www.googleapis.com/auth/script.projects'];
-const TOKEN_PATH = 'credentials.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', (err, content) => {
+fs.readFile('credentials.json', (err, content) => {
   if (err) return console.log('Error loading client secret file:', err);
-  // Authorize a client with credentials, then call the Google Drive API.
+  // Authorize a client with credentials, then call the Google Apps Script API.
   authorize(JSON.parse(content), callAppsScript);
 });
 

--- a/calendar/quickstart/index.js
+++ b/calendar/quickstart/index.js
@@ -21,37 +21,32 @@ const {google} = require('googleapis');
 
 // If modifying these scopes, delete credentials.json.
 const SCOPES = ['https://www.googleapis.com/auth/calendar.readonly'];
-const TOKEN_PATH = 'credentials.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-try {
-  const content = fs.readFileSync('client_secret.json');
+fs.readFile('credentials.json', (err, content) => {
+  if (err) return console.log('Error loading client secret file:', err);
+  // Authorize a client with credentials, then call the Google Calendar API.
   authorize(JSON.parse(content), listEvents);
-} catch (err) {
-  return console.log('Error loading client secret file:', err);
-}
+});
 
 /**
  * Create an OAuth2 client with the given credentials, and then execute the
  * given callback function.
  * @param {Object} credentials The authorization client credentials.
  * @param {function} callback The callback to call with the authorized client.
- * @return {function} if error in reading credentials.json asks for a new one.
  */
 function authorize(credentials, callback) {
   const {client_secret, client_id, redirect_uris} = credentials.installed;
-  let token = {};
   const oAuth2Client = new google.auth.OAuth2(
       client_id, client_secret, redirect_uris[0]);
 
   // Check if we have previously stored a token.
-  try {
-    token = fs.readFileSync(TOKEN_PATH);
-  } catch (err) {
-    return getAccessToken(oAuth2Client, callback);
-  }
-  oAuth2Client.setCredentials(JSON.parse(token));
-  callback(oAuth2Client);
+  fs.readFile(TOKEN_PATH, (err, token) => {
+    if (err) return getAccessToken(oAuth2Client, callback);
+    oAuth2Client.setCredentials(JSON.parse(token));
+    callback(oAuth2Client);
+  });
 }
 
 /**
@@ -76,12 +71,10 @@ function getAccessToken(oAuth2Client, callback) {
       if (err) return callback(err);
       oAuth2Client.setCredentials(token);
       // Store the token to disk for later program executions
-      try {
-        fs.writeFileSync(TOKEN_PATH, JSON.stringify(token));
+      fs.writeFile(TOKEN_PATH, JSON.stringify(token), (err) => {
+        if (err) console.error(err);
         console.log('Token stored to', TOKEN_PATH);
-      } catch (err) {
-        console.error(err);
-      }
+      });
       callback(oAuth2Client);
     });
   });

--- a/classroom/quickstart/index.js
+++ b/classroom/quickstart/index.js
@@ -21,12 +21,12 @@ const {google} = require('googleapis');
 
 // If modifying these scopes, delete credentials.json.
 const SCOPES = ['https://www.googleapis.com/auth/classroom.courses.readonly'];
-const TOKEN_PATH = 'credentials.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', (err, content) => {
+fs.readFile('credentials.json', (err, content) => {
   if (err) return console.log('Error loading client secret file:', err);
-  // Authorize a client with credentials, then call the Google Slides API.
+  // Authorize a client with credentials, then call the Google Classroom API.
   authorize(JSON.parse(content), listCourses);
 });
 

--- a/drive/activity/index.js
+++ b/drive/activity/index.js
@@ -22,12 +22,13 @@ const {google} = require('googleapis');
 // If modifying these scopes, delete credentials.json.
 const SCOPES = ['https://www.googleapis.com/auth/activity',
                 'https://www.googleapis.com/auth/drive.metadata.readonly'];
-const TOKEN_PATH = 'credentials.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', (err, content) => {
+fs.readFile('credentials.json', (err, content) => {
   if (err) return console.log('Error loading client secret file:', err);
-  // Authorize a client with credentials, then call the Google Slides API.
+  // Authorize a client with credentials, then call the Google Drive Activity
+  // API.
   authorize(JSON.parse(content), listActivity);
 });
 

--- a/drive/quickstart/index.js
+++ b/drive/quickstart/index.js
@@ -21,10 +21,10 @@ const {google} = require('googleapis');
 
 // If modifying these scopes, delete credentials.json.
 const SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly'];
-const TOKEN_PATH = 'credentials.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', (err, content) => {
+fs.readFile('credentials.json', (err, content) => {
   if (err) return console.log('Error loading client secret file:', err);
   // Authorize a client with credentials, then call the Google Drive API.
   authorize(JSON.parse(content), listFiles);

--- a/gmail/quickstart/index.js
+++ b/gmail/quickstart/index.js
@@ -21,12 +21,12 @@ const {google} = require('googleapis');
 
 // If modifying these scopes, delete credentials.json.
 const SCOPES = ['https://www.googleapis.com/auth/gmail.readonly'];
-const TOKEN_PATH = 'credentials.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', (err, content) => {
+fs.readFile('credentials.json', (err, content) => {
   if (err) return console.log('Error loading client secret file:', err);
-  // Authorize a client with credentials, then call the Google Sheets API.
+  // Authorize a client with credentials, then call the Gmail API.
   authorize(JSON.parse(content), listLabels);
 });
 

--- a/sheets/quickstart/index.js
+++ b/sheets/quickstart/index.js
@@ -21,10 +21,10 @@ const {google} = require('googleapis');
 
 // If modifying these scopes, delete credentials.json.
 const SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly'];
-const TOKEN_PATH = 'credentials.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', (err, content) => {
+fs.readFile('credentials.json', (err, content) => {
   if (err) return console.log('Error loading client secret file:', err);
   // Authorize a client with credentials, then call the Google Sheets API.
   authorize(JSON.parse(content), listMajors);

--- a/slides/quickstart/index.js
+++ b/slides/quickstart/index.js
@@ -21,10 +21,10 @@ const {google} = require('googleapis');
 
 // If modifying these scopes, delete credentials.json.
 const SCOPES = ['https://www.googleapis.com/auth/presentations.readonly'];
-const TOKEN_PATH = 'credentials.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', (err, content) => {
+fs.readFile('credentials.json', (err, content) => {
   if (err) return console.log('Error loading client secret file:', err);
   // Authorize a client with credentials, then call the Google Slides API.
   authorize(JSON.parse(content), listSlides);

--- a/tasks/quickstart/index.js
+++ b/tasks/quickstart/index.js
@@ -21,12 +21,12 @@ const {google} = require('googleapis');
 
 // If modifying these scopes, delete credentials.json.
 const SCOPES = ['https://www.googleapis.com/auth/tasks.readonly'];
-const TOKEN_PATH = 'credentials.json';
+const TOKEN_PATH = 'token.json';
 
 // Load client secrets from a local file.
-fs.readFile('client_secret.json', (err, content) => {
+fs.readFile('credentials.json', (err, content) => {
   if (err) return console.log('Error loading client secret file:', err);
-  // Authorize a client with credentials, then call the Google Slides API.
+  // Authorize a client with credentials, then call the Google Tasks API.
   authorize(JSON.parse(content), listTaskLists);
 });
 


### PR DESCRIPTION
Change the file names expected for developer credentials and stored tokens to better match the name of the downloaded file.

Developer credentials: `client_secret.json` => `credentials.json`
User credentials / token: `credentials.json` => `token.json`

Also:

- Switch the Admin SDK quickstarts to local token files.
- Fix some incorrect comments.