### PR TITLE
add comment explaining retrieving credentials from JSON file

### DIFF
--- a/gmail/quickstart/index.js
+++ b/gmail/quickstart/index.js
@@ -40,6 +40,7 @@ fs.readFile('credentials.json', (err, content) => {
  * @param {function} callback The callback to call with the authorized client.
  */
 function authorize(credentials, callback) {
+  // use "credentials.web" if your app is of type web server/web app
   const {client_secret, client_id, redirect_uris} = credentials.installed;
   const oAuth2Client = new google.auth.OAuth2(
       client_id, client_secret, redirect_uris[0]);


### PR DESCRIPTION
`credentials.installs` doesn't work when the app is of type webserver/web. `credentials.web` should be used instead of that. added a comment on line 43 to inform future readers about it.