### PR TITLE
credentials.json file has an object with key "web"

### DIFF
--- a/drive/quickstart/index.js
+++ b/drive/quickstart/index.js
@@ -40,7 +40,7 @@ fs.readFile('credentials.json', (err, content) => {
  * @param {function} callback The callback to call with the authorized client.
  */
 function authorize(credentials, callback) {
-  const {client_secret, client_id, redirect_uris} = credentials.installed;
+  const {client_secret, client_id, redirect_uris} = credentials.web;
   const oAuth2Client = new google.auth.OAuth2(
       client_id, client_secret, redirect_uris[0]);
 


### PR DESCRIPTION
The sample code has a key named "installed" which is not defined.

Here is the structure of my credentials.json that was generated in the Google API console:

```json
{"web":{"client_id":"CLIENT_ID","project_id":"PROJECT_ID","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_secret":"CLIENT_SECRET","redirect_uris":["https://login.sendergen.com/auth/googledrive/callback"]}}
```