### PR TITLE
fix: Sheets API scope

### DIFF
--- a/sheets/snippets/sheets_append_values.js
+++ b/sheets/snippets/sheets_append_values.js
@@ -28,7 +28,7 @@ async function appendValues(spreadsheetId, range, valueInputOption, _values) {
   const {google} = require('googleapis');
 
   const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/spreadsheet',
+    scopes: 'https://www.googleapis.com/auth/spreadsheets',
   });
 
   const service = google.sheets({version: 'v4', auth});

--- a/sheets/snippets/sheets_batch_get_values.js
+++ b/sheets/snippets/sheets_batch_get_values.js
@@ -26,7 +26,7 @@ async function batchGetValues(spreadsheetId, _ranges) {
   const {google} = require('googleapis');
 
   const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/spreadsheet',
+    scopes: 'https://www.googleapis.com/auth/spreadsheets',
   });
 
   const service = google.sheets({version: 'v4', auth});

--- a/sheets/snippets/sheets_batch_update_values.js
+++ b/sheets/snippets/sheets_batch_update_values.js
@@ -33,7 +33,7 @@ async function batchUpdateValues(
   const {google} = require('googleapis');
 
   const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/spreadsheet',
+    scopes: 'https://www.googleapis.com/auth/spreadsheets',
   });
 
   const service = google.sheets({version: 'v4', auth});

--- a/sheets/snippets/sheets_conditional_formatting.js
+++ b/sheets/snippets/sheets_conditional_formatting.js
@@ -25,7 +25,7 @@ async function conditionalFormatting(spreadsheetId) {
   const {google} = require('googleapis');
 
   const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/spreadsheet',
+    scopes: 'https://www.googleapis.com/auth/spreadsheets',
   });
 
   const service = google.sheets({version: 'v4', auth});

--- a/sheets/snippets/sheets_create.js
+++ b/sheets/snippets/sheets_create.js
@@ -25,7 +25,7 @@ async function create(title) {
   const {google} = require('googleapis');
 
   const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/spreadsheet',
+    scopes: 'https://www.googleapis.com/auth/spreadsheets'
   });
 
   const service = google.sheets({version: 'v4', auth});

--- a/sheets/snippets/sheets_create.js
+++ b/sheets/snippets/sheets_create.js
@@ -25,7 +25,7 @@ async function create(title) {
   const {google} = require('googleapis');
 
   const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/spreadsheets'
+    scopes: 'https://www.googleapis.com/auth/spreadsheets',
   });
 
   const service = google.sheets({version: 'v4', auth});

--- a/sheets/snippets/sheets_get_values.js
+++ b/sheets/snippets/sheets_get_values.js
@@ -26,7 +26,7 @@ async function getValues(spreadsheetId, range) {
   const {google} = require('googleapis');
 
   const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/spreadsheet',
+    scopes: 'https://www.googleapis.com/auth/spreadsheets',
   });
 
   const service = google.sheets({version: 'v4', auth});

--- a/sheets/snippets/sheets_pivot_table.js
+++ b/sheets/snippets/sheets_pivot_table.js
@@ -25,7 +25,7 @@ async function pivotTable(spreadsheetId) {
   const {google} = require('googleapis');
 
   const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/spreadsheet',
+    scopes: 'https://www.googleapis.com/auth/spreadsheets',
   });
 
   const service = google.sheets({version: 'v4', auth});

--- a/sheets/snippets/sheets_update_values.js
+++ b/sheets/snippets/sheets_update_values.js
@@ -28,7 +28,7 @@ async function updateValues(spreadsheetId, range, valueInputOption, _values) {
   const {google} = require('googleapis');
 
   const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/spreadsheet',
+    scopes: 'https://www.googleapis.com/auth/spreadsheets',
   });
 
   const service = google.sheets({version: 'v4', auth});

--- a/sheets/snippets/test/helpers.js
+++ b/sheets/snippets/test/helpers.js
@@ -27,7 +27,7 @@ class Helpers {
   constructor() {
     const auth = new GoogleAuth({
       scopes: [
-        'https://www.googleapis.com/auth/spreadsheet',
+        'https://www.googleapis.com/auth/spreadsheets',
         'https://www.googleapis.com/auth/drive',
       ],
     });

--- a/slides/snippets/slides_text_merging.js
+++ b/slides/snippets/slides_text_merging.js
@@ -28,7 +28,7 @@ async function textMerging(templatePresentationId, dataSpreadsheetId) {
     scopes: [
       'https://www.googleapis.com/auth/presentations',
       'https://www.googleapis.com/auth/drive',
-      'https://www.googleapis.com/auth/spreadsheet',
+      'https://www.googleapis.com/auth/spreadsheets',
     ],
   });
 


### PR DESCRIPTION
Sheets API scopes have a typo and should be `https://www.googleapis.com/auth/spreadsheets`

See https://developers.google.com/identity/protocols/oauth2/scopes#sheets