### PR TITLE
Change customer key name to customerId

### DIFF
--- a/adminSDK/directory/index.js
+++ b/adminSDK/directory/index.js
@@ -90,7 +90,7 @@ async function authorize() {
 async function listUsers(auth) {
   const service = google.admin({version: 'directory_v1', auth});
   const res = await service.users.list({
-    customer: 'my_customer',
+    customerId: 'my_customer',
     maxResults: 10,
     orderBy: 'email',
   });


### PR DESCRIPTION
The service.users.list function on line 92 fails. Error message states that you are missing the customer ID. Changing the object key name from customer to customerId resolves this issue.