### PR TITLE
chore: Update code examples for v3 API to use `requestBody` instead…

### DIFF
--- a/drive/snippets/drive_v3/appdata_snippets/upload_appdata.js
+++ b/drive/snippets/drive_v3/appdata_snippets/upload_appdata.js
@@ -40,7 +40,7 @@ async function uploadAppdata() {
   };
   try {
     const file = await service.files.create({
-      resource: fileMetadata,
+      requestBody: fileMetadata,
       media: media,
       fields: 'id',
     });

--- a/drive/snippets/drive_v3/file_snippets/create_folder.js
+++ b/drive/snippets/drive_v3/file_snippets/create_folder.js
@@ -36,7 +36,7 @@ async function createFolder() {
   };
   try {
     const file = await service.files.create({
-      resource: fileMetadata,
+      requestBody: fileMetadata,
       fields: 'id',
     });
     console.log('Folder Id:', file.data.id);

--- a/drive/snippets/drive_v3/file_snippets/create_shortcut.js
+++ b/drive/snippets/drive_v3/file_snippets/create_shortcut.js
@@ -37,7 +37,7 @@ async function createShortcut() {
 
   try {
     const file = await service.files.create({
-      resource: fileMetadata,
+      requestBody: fileMetadata,
       fields: 'id',
     });
     console.log('File Id:', file.data.id);

--- a/drive/snippets/drive_v3/file_snippets/touch_file.js
+++ b/drive/snippets/drive_v3/file_snippets/touch_file.js
@@ -38,7 +38,7 @@ async function touchFile(fileId, Timestamp) {
   try {
     const file = await service.files.update({
       fileId: fileId,
-      resource: fileMetadata,
+      requestBody: fileMetadata,
       fields: 'id, modifiedTime',
     });
     console.log('Modified time:', file.data.modifiedTime);

--- a/drive/snippets/drive_v3/file_snippets/upload_to_folder.js
+++ b/drive/snippets/drive_v3/file_snippets/upload_to_folder.js
@@ -44,7 +44,7 @@ async function uploadToFolder(folderId) {
 
   try {
     const file = await service.files.create({
-      resource: fileMetadata,
+      requestBody: fileMetadata,
       media: media,
       fields: 'id',
     });

--- a/drive/snippets/drive_v3/file_snippets/upload_with_conversion.js
+++ b/drive/snippets/drive_v3/file_snippets/upload_with_conversion.js
@@ -40,7 +40,7 @@ async function uploadWithConversion() {
 
   try {
     const file = await service.files.create({
-      resource: fileMetadata,
+      requestBody: fileMetadata,
       media: media,
       fields: 'id',
     });


### PR DESCRIPTION
of `resource`

This is a 5 years old issue : https://github.com/googleapis/google-api-nodejs-client/issues/1885